### PR TITLE
Update Recyclarr Logo

### DIFF
--- a/templates/recyclarr.xml
+++ b/templates/recyclarr.xml
@@ -17,7 +17,7 @@ Formerly named "Trash Updater".</Overview>
   <Category>Tools:</Category>
   <WebUI/>
   <TemplateURL/>
-  <Icon>https://raw.githubusercontent.com/tritones/unraid-templates/main/templates/img/recyclarr.png</Icon>
+  <Icon>https://raw.githubusercontent.com/recyclarr/recyclarr/master/ci/notify/trash-icon.png</Icon>
   <ExtraParams/>
   <PostArgs/>
   <CPUset/>


### PR DESCRIPTION
Recyclarr has a preferred logo! This updates the XML template for Community Applications (CA) to update this.