### PR TITLE
Add PUID & PGID variables to Recyclarr

### DIFF
--- a/templates/recyclarr.xml
+++ b/templates/recyclarr.xml
@@ -46,8 +46,20 @@ Formerly named "Trash Updater".</Description>
       <Name>CRON_SCHEDULE</Name>
       <Mode/>
     </Variable>
+    <Variable>
+      <Value>99</Value>
+      <Name>PUID</Name>
+      <Mode/>
+    </Variable>
+    <Variable>
+      <Value>100</Value>
+      <Name>PGID</Name>
+      <Mode/>
+    </Variable>
   </Environment>
   <Labels/>
   <Config Name="AppData Config Path" Target="/config" Default="" Mode="rw" Description="This is the application data directory for Recyclarr. In this directory, files like recyclarr.yml and settings.yml exist, as well as logs, cache, and other directories." Type="Path" Display="always" Required="true" Mask="false"/>
   <Config Name="CRON_SCHEDULE" Target="CRON_SCHEDULE" Default="@daily" Mode="" Description="Standard cron syntax for how often you want Recyclarr to run. See: https://github.com/recyclarr/recyclarr/wiki/Docker#cron-mode" Type="Variable" Display="always" Required="false" Mask="false">@daily</Config>
+  <Config Name="PUID" Target="PUID" Default="99" Mode="" Description="Container Variable: PUID" Type="Variable" Display="always" Required="false" Mask="false">99</Config>
+  <Config Name="PGID" Target="PGID" Default="100" Mode="" Description="Container Variable: PGID" Type="Variable" Display="always" Required="false" Mask="false">100</Config>
 </Container>


### PR DESCRIPTION
Recyclarr has a new container release with support of PUID & PGID. This adds these variables to the unRAID template and sets them to defaults (PUID=99; PGID=100).