### PR TITLE
New Recyclarr variable RECYCLARR_CREATE_CONFIG

### DIFF
--- a/templates/recyclarr.xml
+++ b/templates/recyclarr.xml
@@ -50,8 +50,14 @@ Formerly named "Trash Updater".</Description>
       <Name>CRON_SCHEDULE</Name>
       <Mode/>
     </Variable>
+    <Variable>
+      <Value>false</Value>
+      <Name>RECYCLARR_CREATE_CONFIG</Name>
+      <Mode/>
+    </Variable>
   </Environment>
   <Labels/>
   <Config Name="AppData Config Path" Target="/config" Default="" Mode="rw" Description="This is the application data directory for Recyclarr. In this directory, files like recyclarr.yml and settings.yml exist, as well as logs, cache, and other directories." Type="Path" Display="always" Required="true" Mask="false"/>
   <Config Name="CRON_SCHEDULE" Target="CRON_SCHEDULE" Default="@daily" Mode="" Description="Standard cron syntax for how often you want Recyclarr to run. See: https://github.com/recyclarr/recyclarr/wiki/Docker#cron-mode" Type="Variable" Display="always" Required="false" Mask="false">@daily</Config>
+  <Config Name="RECYCLARR_CREATE_CONFIG" Target="RECYCLARR_CREATE_CONFIG" Default="false" Mode="" Description=" Starting with version 3.0.0, whether the container should create a default recyclarr.yml on start-up if it does not exist.&#13;&#10;&#13;&#10;This is default set to " Type="Variable" Display="always" Required="false" Mask="false">false</Config>
 </Container>


### PR DESCRIPTION
## Recyclarr Container Template Update

This adds a new environment variable, `RECYCLARR_CREATE_CONFIG`, which instructs the container to create a default `recyclarr.yml` on start-up if it does not exist.

This environment variable is default set to `false` to avoid impacting existing users.

This solved the change request here: https://github.com/tritones/unraid-templates/issues/8